### PR TITLE
Updating code to call Mixin with no parameters 

### DIFF
--- a/generators/app/templates/docs/js/docs.js
+++ b/generators/app/templates/docs/js/docs.js
@@ -265,10 +265,9 @@ function writeMixinCall (component, $component) {
   var fields = $component.find('form').serializeArray()
   var block = $component.find('[name=blockField]').val()
 
-  var str = '+' + component
+  var str = '+' + component + '('
   if (fields.length) {
-    str += '('
-
+    
     $.each(fields, function (index, field) {
       // If it's boolean or json object/array don't wrap quotes around it
       if (field.value === 'true' || field.value === 'false' || field.value.match(/^\{|\[/)) {
@@ -280,7 +279,7 @@ function writeMixinCall (component, $component) {
       }
     })
 
-    str = str.slice(0, -2) + ')'
+    str = str.replace(/,\s*$/, '') + ')'
   }
   if (block) {
     // If the block contains tabs we shouldn't escape


### PR DESCRIPTION
Noticed when dealing with a metadata mixin.  The code adds an opening parenthesis, and if ```fields``` is empty (but exists) the code strips the last 2 chars and adds a ```)```.

![image](https://user-images.githubusercontent.com/464876/56817995-a1017880-683e-11e9-8e05-7dc1dada4cb0.png)

Alternatively, this code replaces any trailing comma and spaces and then adds a closing parenthesis.

![image](https://user-images.githubusercontent.com/464876/56818315-47e61480-683f-11e9-883f-3e90fdda293c.png)